### PR TITLE
Added a face up state field to Card that defaults to false

### DIFF
--- a/src/main/java/com/skillstorm/assets/Card.java
+++ b/src/main/java/com/skillstorm/assets/Card.java
@@ -1,9 +1,11 @@
 package com.skillstorm.assets;
 
 // The Card class, not specifically mentioned in the requirements, but it's a good design decision to delegate.
+
 public class Card {
     private Suit suit;
     private Rank rank;
+    private boolean faceUp = false;
 
     private Card(Suit suit, Rank rank) {
         this.suit = suit;
@@ -16,6 +18,14 @@ public class Card {
 
     public Rank getRank() {
         return rank;
+    }
+
+    public boolean isFaceUp() {
+        return faceUp;
+    }
+
+    public void setFaceUp(boolean faceUp) {
+        this.faceUp = faceUp;
     }
 
     public static Card[] generateCards() {


### PR DESCRIPTION
I've added a state field to the Card class to indicate if it's face up or not. When we get the game's logic running, we should be able to hide the house's face down cards from the player. By default, it will be face down, and when cards are initially dealt, the state can be changed to face up (true) for the first card. If we ever decided to allow multiple players for the game, this would also be helpful to hide players' hands from each other, minus that one face up card.