### PR TITLE
Fix to warning in the Deck shuffle method.

### DIFF
--- a/src/main/java/com/skillstorm/assets/Deck.java
+++ b/src/main/java/com/skillstorm/assets/Deck.java
@@ -3,26 +3,26 @@ package com.skillstorm.assets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.Queue;
+import java.util.List;
 
 // Deck All cards currently in the Deck Shuffle method Deal method Card Suit Value
 public class Deck {
-    private Queue<Card> cards;
+    private List<Card> cards;
 
     public Deck(Card[] cards) {
         this.cards = new LinkedList<>(Arrays.asList(cards));
     }
 
-    public Queue<Card> getCards() {
+    public List<Card> getCards() {
         return cards;
     }
 
     public Card draw() {
-        return cards.poll();
+        return cards.remove(0);
     }
 
     public void shuffle() {
-        Collections.shuffle((Arrays.asList(cards)));
+        Collections.shuffle(cards);
     }
     
     @Override


### PR DESCRIPTION
There was an uncaught cast warning for the shuffle method in Deck. This fix uses Arrays.asList() for the cast, which is much cleaner and without a warning.