### PR TITLE
Implement Naturals rule.

### DIFF
--- a/src/main/java/com/skillstorm/logic/GameLogic.java
+++ b/src/main/java/com/skillstorm/logic/GameLogic.java
@@ -227,14 +227,11 @@ public class GameLogic {
         if (house.getHand().total() == 21) {
             return true;
         } else {
-            boolean naturalPlayer = false;
             for (Player player : playerList) {
                 if (player.getHand().total() == 21) {
                     bets.put(player.getName(), bets.get(player.getName()) * 1.25);
-                    naturalPlayer = true;
                 }
             }
-            if (naturalPlayer) return true;
         }
         return false;
     }


### PR DESCRIPTION
Adding Naturals check, if any hand contains a natural after dealing phase, then player turns are skipped. This can't be merged into feature_logicflow until after the settlement changes are merged, as the houseActions will need to be included within the block after the naturals check occurs.